### PR TITLE
Added prerequisites to README.md (build-essential, libreadline-dev).

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -10,6 +10,15 @@ LuaDec is free software and uses the same license as the original LuaDec.
 
 Compiling
 ---------
+
+### Prerequisites
+
+```
+sudo apt-get install build-essential libreadline-dev 
+```
+
+### Building
+
 ```
 git clone https://github.com/viruscamp/luadec
 cd luadec


### PR DESCRIPTION
GNU make complains about the lack of readline/readline.h, which can be fixed by installing libreadline-dev. Probably this should be specified in README.md.