### PR TITLE
Fix incorrect OP_CLOSURE decompilation (register C -> Bx)

### DIFF
--- a/luadec/decompile.c
+++ b/luadec/decompile.c
@@ -3047,7 +3047,7 @@ LOGIC_NEXT_JMP:
 			int i;
 			int uvn;
 			int cfnum = functionnum;
-			Proto* cf = f->p[c];
+			Proto* cf = f->p[bc];
 			char* tmpname = (char*)calloc(strlen(funcnumstr) + 64, sizeof(char));
 
 			uvn = NUPS(cf);
@@ -3123,17 +3123,17 @@ LOGIC_NEXT_JMP:
 			if (func_checking) {
 				char* code = NULL;
 				char* newfuncnumstr = (char*)calloc(strlen(funcnumstr) + 12, sizeof(char));
-				functionnum = c;
-				sprintf(newfuncnumstr, "%s_%d", funcnumstr, c);
+				functionnum = bc;
+				sprintf(newfuncnumstr, "%s_%d", funcnumstr, functionnum);
 				code = PrintFunctionOnlyParamsAndUpvalues(cf, F->indent, newfuncnumstr);
 				StringBuffer_setBuffer(str, code);
 			} else if (!process_sub) {
-				StringBuffer_printf(str, "DecompiledFunction_%s_%d", funcnumstr, c);
+				StringBuffer_printf(str, "DecompiledFunction_%s_%d", funcnumstr, bc);
 			} else {
 				char* code = NULL;
 				char* newfuncnumstr = (char*)calloc(strlen(funcnumstr) + 12, sizeof(char));
-				functionnum = c;
-				sprintf(newfuncnumstr, "%s_%d", funcnumstr, c);
+				functionnum = bc;
+				sprintf(newfuncnumstr, "%s_%d", funcnumstr, functionnum);
 				code = ProcessCode(cf, F->indent, 0, newfuncnumstr);
 				StringBuffer_setBuffer(str, code);
 			}


### PR DESCRIPTION
Fix #74.

The decompiler currently handles `OP_CLOSURE` improperly, and looks for the function index in register C, when Lua uses combined register Bx. This will actually work as expected with vanilla Lua implementations that use the typical `Op-A-C-B` opcode-operand ordering, as C happens to be the lower 9 bits of Bx, but will fail with Lua implementations that use a different ordering.

This patch makes some tiny changes to `ProcessCode` so that it reads the function index from Bx instead.

(The disassembler part of luadec already reads from Bx instead of C, so no changes are necessary there.)