### PR TITLE
Add instruction ranges to locals desc in brief mode.

### DIFF
--- a/ChunkSpy/ChunkSpy51.lua
+++ b/ChunkSpy/ChunkSpy51.lua
@@ -1652,7 +1652,8 @@ function ChunkSpy(chunk_name, chunk)
         FormatLine(config.size_int, "  startpc ("..locvar.startpc..")", locvar.pos_startpc)
         FormatLine(config.size_int, "  endpc   ("..locvar.endpc..")",locvar.pos_endpc)
         BriefLine(".local"..config.DISPLAY_SEP..EscapeString(locvar.varname, 1)
-                  ..config.DISPLAY_SEP..config.DISPLAY_COMMENT..(i - 1))
+                  ..config.DISPLAY_SEP..config.DISPLAY_COMMENT..(i - 1)
+                  ..config.DISPLAY_SEP..locvar.startpc.."-"..locvar.endpc)
       end
     end
 

--- a/ChunkSpy/ChunkSpy52.lua
+++ b/ChunkSpy/ChunkSpy52.lua
@@ -1718,7 +1718,8 @@ function ChunkSpy(chunk_name, chunk)
         FormatLine(config.size_int, "  startpc ("..locvar.startpc..")", locvar.pos_startpc)
         FormatLine(config.size_int, "  endpc   ("..locvar.endpc..")",locvar.pos_endpc)
         BriefLine(".local"..config.DISPLAY_SEP..EscapeString(locvar.varname, 1)
-                  ..config.DISPLAY_SEP..config.DISPLAY_COMMENT..(i - 1))
+                  ..config.DISPLAY_SEP..config.DISPLAY_COMMENT..(i - 1)
+                  ..config.DISPLAY_SEP..locvar.startpc.."-"..locvar.endpc)
       end
     end
 

--- a/ChunkSpy/ChunkSpy53.lua
+++ b/ChunkSpy/ChunkSpy53.lua
@@ -1824,7 +1824,8 @@ function ChunkSpy(chunk_name, chunk)
         FormatLine(config.size_int, "  startpc ("..locvar.startpc..")", locvar.pos_startpc)
         FormatLine(config.size_int, "  endpc   ("..locvar.endpc..")",locvar.pos_endpc)
         BriefLine(".local"..config.DISPLAY_SEP..EscapeString(locvar.varname, 1)
-                  ..config.DISPLAY_SEP..config.DISPLAY_COMMENT..(i - 1))
+                  ..config.DISPLAY_SEP..config.DISPLAY_COMMENT..(i - 1)
+                  ..config.DISPLAY_SEP..locvar.startpc.."-"..locvar.endpc)
       end
     end
 


### PR DESCRIPTION
Currently, the only thing brief display mode of ChunkSpy shows for locals, besides their names, is the local "number," which is a basically useless value. (Nothing ever refers to local debug records by number, and you can't use them to translate to/from registers in the general case.) This patch adds the startpc/endpc instruction ranges to the brief display, which is much more useful information that can help (manually) translate registers to/from locals.