### PR TITLE
Add required libraries to readme compile instructions

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,6 +11,8 @@ LuaDec is free software and uses the same license as the original LuaDec.
 Compiling
 ---------
 ```
+sudo apt install libreadline6-dev
+sudo apt install libncurses5-dev
 git clone https://github.com/viruscamp/luadec
 cd luadec
 git submodule update --init lua-5.1


### PR DESCRIPTION
Add required libraries to readme compile instructions:
```
sudo apt install libreadline6-dev
sudo apt install libncurses5-dev
```

People getting mad because they can't compile neither do a search in the issues tab 🧻 sniff, sniff 🧻 